### PR TITLE
Add StartMail to secureDomains.txt

### DIFF
--- a/secureDomains.txt
+++ b/secureDomains.txt
@@ -190,6 +190,7 @@ sociologist.com
 solution4u.com
 songwriter.net
 spainmail.com
+startmail.com
 surgical.net
 swedenmail.com
 swissmail.com


### PR DESCRIPTION
# add startmail.com to secureDomains.txt

StartMail is incorrectly listed as a disposable email provider, which harms its reputation. It is not. This PR corrects this by adding it to `secureDomains.txt`, aligning with providers like Tutanota (#21) and ProtonMail (#28).
