### PR TITLE
Add the temporary domains from https://temp-mail.lol/

### DIFF
--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -14,6 +14,7 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
      * @var array
      */
     protected $textDenyFiles = [
+        'https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/internalLists/temp-mail.lol.txt',
         'https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/internalLists/tmail-mmomekong-com.txt',
         'https://raw.githubusercontent.com/andreis/disposable-email-domains/master/domains.txt',
         'https://raw.githubusercontent.com/andreis/disposable-email-domains/master/domains_mx.txt',

--- a/internalLists/temp-mail.lol.txt
+++ b/internalLists/temp-mail.lol.txt
@@ -1,0 +1,5 @@
+disposely.xyz
+disposly.com
+fastestflex.com
+temp-mail.lol
+homecut.pro


### PR DESCRIPTION
Add the temporary domains from https://temp-mail.lol/

Fixes https://github.com/amieiro/disposable-email-domains/issues/31