### PR TITLE
Add sudomail.com to the secure domains list

### DIFF
--- a/secureDomains.txt
+++ b/secureDomains.txt
@@ -191,6 +191,7 @@ solution4u.com
 songwriter.net
 spainmail.com
 startmail.com
+sudomail.com
 surgical.net
 swedenmail.com
 swissmail.com


### PR DESCRIPTION
Related to #38

## Proposed changes

* Add `sudomail.com` to `secureDomains.txt`.

## Why are these changes being made?

Issue #38 is a request from Brian at Anonyome Labs (MySudo) asking why `sudomail.com` is flagged as disposable and to reconsider it.

`sudomail.com` is the email domain MySudo assigns to its users. MySudo is a paid subscription identity product (SudoGo, SudoPro, SudoMax) from Anonyome Labs, a PCI-DSS compliant and SOC 2 Type II certified company. The addresses are persistent identities tied to a paying account, used for ongoing access, not single-use throwaway inboxes. That puts it in the same category as the privacy and alias providers this list already allows, such as SimpleLogin, Proton, Tuta, and StartMail.

There is precedent. The largest upstream source, the `disposable-email-domains/disposable-email-domains` project, got the identical request back in 2019 (their issue #192). The maintainer agreed the service is not disposable and removed all the sudo domains. Their current blocklist has none of them, and neither does auth0-signals.

Why edit `secureDomains.txt` rather than `denyDomains.txt` directly: the deny and allow files are regenerated every fifteen minutes by aggregating around 28 upstream blocklists (see `CreateDisposableEmailDomainsFilesCommand.php`). `sudomail.com` still appears in several of those sources, so deleting the line from `denyDomains.txt` would do nothing, it would reappear on the next run. `secureDomains.txt` is the only durable lever: `removeSecureDomains` drops the domain and its subdomains from the deny list, and `addSecureDomains` adds it to the allow list.

Scope: this change covers `sudomail.com` only, which is the domain named in the issue. The list also contains `sudomail.biz`, `sudomail.net`, and `mysudomail.com`. Those are separate registrable domains and are not affected by this entry. They can be handled separately once the requester confirms which domains they actively use.

## Testing instructions

1. From `creator/`, run the generator: `php artisan ded:create-files`.
2. Confirm `sudomail.com` no longer appears in `denyDomains.txt` / `denyDomains.json` and now appears in `allowDomains.txt` / `allowDomains.json`.
3. Confirm `sudomail.biz`, `sudomail.net`, and `mysudomail.com` still remain in the deny files, since this entry should not touch them.