### PR TITLE
Add Cloaked corporate domains to the secure domains list

### DIFF
--- a/secureDomains.txt
+++ b/secureDomains.txt
@@ -43,6 +43,9 @@ chef.net
 chemist.com
 chinamail.com
 clerk.com
+cloaked.com
+cloaked.dev
+cloaked.id
 clubmember.org
 collector.org
 columnist.com


### PR DESCRIPTION
Related to #39

## Proposed changes

* Add `cloaked.com`, `cloaked.dev`, and `cloaked.id` to `secureDomains.txt`.

## Why are these changes being made?

Issue #39 is a false-positive report from the Cloaked founder. `cloaked.id` was being returned as disposable, and the request asks to clear `cloaked.id`, `cloaked.com`, and `cloaked.dev`.

Of the three, only `cloaked.id` is currently in the deny list, pulled from a single source, `throwaway.cloud`. `cloaked.com` and `cloaked.dev` are not in any of the upstream sources today, so they are added here as a precaution against the same false positive happening later.

These three are corporate domains for Cloaked, Inc., not throwaway inboxes:

- All three resolve to Google Workspace MX records (`aspmx.l.google.com`). Google Workspace is built for a bounded set of employee mailboxes, not for handing out unlimited relay aliases.
- `cloaked.com` was registered in 1998 and carries the company's employee email, `cloaked.dev` dates to 2014, and `cloaked.id` to 2020.
- The canonical `disposable-email-domains/disposable-email-domains` list does not include any of them, and `throwaway.cloud`'s own GitHub mirror has already dropped `cloaked.id`. The reporter also filed an upstream fix at iocium/feedback.throwaway.cloud#5.

The detail worth recording, since Cloaked itself sells email masking: their masking and relay product runs on a separate domain, `cloak.id` (singular), whose MX points to SendGrid, the infrastructure you would expect for forwarding mail across many masked aliases. `cloak.id` and `cloaked.id` are different registrable domains, so allowlisting `cloaked.id` does not allowlist the masking service. `cloak.id` is not part of this request and is not in the list, so it stays untouched.

On the mechanism: the deny and allow files are regenerated every fifteen minutes from around 28 upstream sources (`CreateDisposableEmailDomainsFilesCommand.php`). Editing `denyDomains.txt` directly would not hold, the entry would return on the next run. `secureDomains.txt` is the durable fix: `removeSecureDomains` drops the domain from the deny list and `addSecureDomains` adds it to the allow list.

## Testing instructions

1. From `creator/`, run the generator: `php artisan ded:create-files`.
2. Confirm `cloaked.id` no longer appears in `denyDomains.txt` / `denyDomains.json` and that all three domains appear in `allowDomains.txt` / `allowDomains.json`.
3. Confirm `cloak.id` (the masking domain) is not added anywhere, since it is not part of this change.