### PR TITLE
Add Castle as a disposable-email deny source

### DIFF
--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -19,6 +19,7 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
         'https://raw.githubusercontent.com/andreis/disposable-email-domains/master/domains.txt',
         'https://raw.githubusercontent.com/andreis/disposable-email-domains/master/domains_mx.txt',
         'https://raw.githubusercontent.com/auth0-signals/disposable-email-domains/master/dea.txt',
+        'https://raw.githubusercontent.com/castle/disposable-email-domains/master/disposable-email-domains.txt',
         'https://raw.githubusercontent.com/di/disposable-email-domains/master/source_data/disposable_email_blocklist.conf',
         'https://raw.githubusercontent.com/disposable/disposable-email-domains/master/domains.txt',
         'https://raw.githubusercontent.com/disposable-email-domains/disposable-email-domains/master/disposable_email_blocklist.conf',


### PR DESCRIPTION
## Proposed changes

* Add `castle/disposable-email-domains` to the deny text sources (`$textDenyFiles`) in `CreateDisposableEmailDomainsFilesCommand`.

URL: `https://raw.githubusercontent.com/castle/disposable-email-domains/master/disposable-email-domains.txt`

## Why are these changes being made?

The deny list is built from around two dozen upstream sources. Castle, a fraud-prevention company, publishes a list of the 1,000 most active disposable domains and refreshes it daily.

I compared it against the current deny set (197,948 unique domains). About 533 of Castle's entries are not covered by any source already in use, so it adds genuinely new domains rather than duplicating what is there.

Quality and risk are good for this list:

- The new entries are concentrated in abuse-prone TLDs (`.site`, `.cc`, `.xyz`, `.cn`, `.top`, `.cd`) and read as throwaway or typosquat domains (for example `outiook.com`, `shortenmail.com`, and temp-mail subdomains). A manual sample turned up no legitimate domains, so the false-positive risk is low.
- It is MIT licensed, the same license as this project.
- It is plain text with one domain per line and no header, so the existing `$textDenyFiles` parser handles it without changes.

For comparison, I also evaluated `doodad-labs/disposable-email-domains` (17k to 72k net-new) and chose not to add it: the net-new set is heavy on `.com` and includes legitimate domains such as `talktalk.net` and `yahoo.com.pa`, and the list is GPL-3.0. Other candidates (`groundcat`, `7c/fakefilter`, `daisy1754/jp-disposable-emails`, `said7388/suspicious-email-domains`) were already fully covered or out of scope.

## Testing instructions

1. From `creator/`, run the generator: `php artisan ded:create-files`.
2. Confirm the run completes and fetches the new Castle URL without errors.
3. Confirm `denyDomains.txt` / `denyDomains.json` grow by roughly 500 domains and that spot-checked Castle entries (for example `shortenmail.com`) now appear in the deny files.
4. Confirm domains in `allowDomains.txt` and `secureDomains.txt` are still excluded from the deny files.