### PR TITLE
Guard against deny list shrinkage and log domain counts on commit

### DIFF
--- a/.github/workflows/run-every-quarter-hour.yml
+++ b/.github/workflows/run-every-quarter-hour.yml
@@ -40,5 +40,13 @@ jobs:
         run: |
           git config --global user.name "Jesús Amieiro"
           git config --global user.email "amieiro@users.noreply.github.com"
-          git diff --quiet || git commit -am "Automatic generation"
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          deny_total=$(grep -c '' denyDomains.txt)
+          allow_total=$(grep -c '' allowDomains.txt)
+          deny_stat=$(git diff --numstat -- denyDomains.txt | awk '{print "+"$1" -"$2}')
+          allow_stat=$(git diff --numstat -- allowDomains.txt | awk '{print "+"$1" -"$2}')
+          git commit -am "Automatic generation: deny ${deny_stat:-+0 -0} (total ${deny_total}), allow ${allow_stat:-+0 -0} (total ${allow_total})"
           git push

--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -91,6 +91,15 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     protected $secureDomainsFile = '../secureDomains.txt';
 
     /**
+     * The minimum fraction of the previous deny list size that a new run must
+     * reach before it is allowed to overwrite the files. Guards against an
+     * upstream source going down and silently shrinking the published list.
+     *
+     * @var float
+     */
+    protected float $shrinkThreshold = 0.9;
+
+    /**
      * The name and signature of the console command.
      *
      * @var string
@@ -137,6 +146,22 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
             $denyDomains = $this->removeSecureDomains($denyDomains);
             $denyDomains = $this->removeDuplicates($denyDomains);
             $denyDomains = $this->removeAllowedDomains($denyDomains, $allowDomains);
+
+            $previousDenyCount = $this->countExistingDomains($this->textDenyFile);
+            if (!$this->isDenyListSizeAcceptable(count($denyDomains), $previousDenyCount)) {
+                $message = sprintf(
+                    'Aborting: the new deny list (%d domains) dropped below %d%% of the previous one (%d domains). '
+                    . 'Files were not overwritten, most likely an upstream source failed.',
+                    count($denyDomains),
+                    (int) round($this->shrinkThreshold * 100),
+                    $previousDenyCount
+                );
+                Log::error($message);
+                $this->error($message);
+
+                return 1; // Failure, leave the existing files untouched
+            }
+
             $this->saveToFiles($denyDomains, $this->textDenyFile, $this->jsonDenyFile);
 
             $allowDomains = $this->addSecureDomains($allowDomains);
@@ -275,6 +300,42 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     protected function removeAllowedDomains(array $denyDomains, array $allowDomains): array
     {
         return array_diff($denyDomains, $allowDomains);
+    }
+
+    /**
+     * Decide whether a newly built deny list is large enough to publish.
+     *
+     * A run is acceptable when there is no previous baseline (first run) or
+     * when the new size is at least $shrinkThreshold of the previous size.
+     *
+     * @param int $newCount
+     * @param int $previousCount
+     * @return bool
+     */
+    public function isDenyListSizeAcceptable(int $newCount, int $previousCount): bool
+    {
+        if ($previousCount <= 0) {
+            return true;
+        }
+
+        return $newCount >= (int) floor($previousCount * $this->shrinkThreshold);
+    }
+
+    /**
+     * Count the domains stored in an existing generated file.
+     *
+     * @param string $file
+     * @return int
+     */
+    protected function countExistingDomains(string $file): int
+    {
+        if (!is_file($file)) {
+            return 0;
+        }
+
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        return $lines === false ? 0 : count($lines);
     }
 
     /**

--- a/creator/tests/Unit/DenyListSizeGuardTest.php
+++ b/creator/tests/Unit/DenyListSizeGuardTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\CreateDisposableEmailDomainsFilesCommand;
+use PHPUnit\Framework\TestCase;
+
+class DenyListSizeGuardTest extends TestCase
+{
+    private CreateDisposableEmailDomainsFilesCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->command = new CreateDisposableEmailDomainsFilesCommand;
+    }
+
+    public function test_first_run_without_a_previous_baseline_is_accepted(): void
+    {
+        $this->assertTrue($this->command->isDenyListSizeAcceptable(100, 0));
+    }
+
+    public function test_a_larger_list_is_accepted(): void
+    {
+        $this->assertTrue($this->command->isDenyListSizeAcceptable(200, 100));
+    }
+
+    public function test_a_small_shrink_within_the_threshold_is_accepted(): void
+    {
+        // floor(100 * 0.9) = 90, so 95 is acceptable.
+        $this->assertTrue($this->command->isDenyListSizeAcceptable(95, 100));
+    }
+
+    public function test_a_shrink_exactly_at_the_threshold_is_accepted(): void
+    {
+        $this->assertTrue($this->command->isDenyListSizeAcceptable(90, 100));
+    }
+
+    public function test_a_catastrophic_shrink_is_rejected(): void
+    {
+        // floor(100 * 0.9) = 90, so 50 is below the floor and must be rejected.
+        $this->assertFalse($this->command->isDenyListSizeAcceptable(50, 100));
+    }
+}


### PR DESCRIPTION
## Proposed changes

* Add a shrinkage guard to `CreateDisposableEmailDomainsFilesCommand`: if a run produces a deny list smaller than 90% of the previously published one, the command logs an error, leaves the existing files untouched, and exits non-zero.
* Add the first real unit tests for the project (`DenyListSizeGuardTest`), covering the first run, growth, the threshold edge, and a catastrophic drop.
* Make the scheduled workflow record `+added / -removed (total)` counts for both the deny and allow lists in the automatic commit message, and skip the commit when nothing changed.

## Why are these changes being made?

The deny list is rebuilt every fifteen minutes from around two dozen external sources, and the workflow commits and pushes whatever the run produces. If a source goes offline, returns an error page, or moves its URL, the fetch fails quietly and that source drops out of the run. Nothing today notices a sudden collapse in size, so a broken upstream could publish a deny list missing thousands of domains to everyone consuming the raw files.

The guard puts a floor under that. A run has to stay within 90% of the previous size to overwrite the files. On a healthy run nothing changes. On a bad run the command aborts before writing, the existing files stay in place, and the workflow goes red so the failure is visible instead of silent. The first run, or any run without a previous baseline, is always allowed through.

The decision logic lives in `isDenyListSizeAcceptable`, kept as a small pure method so it can be unit tested without network or file access. Those tests also seed a suite the project did not have before.

The commit-message change is for transparency. Every run currently commits "Automatic generation" with no detail, so the history gives no signal about what changed. Recording the added, removed, and total counts makes the log auditable and makes an anomaly easy to spot at a glance.

## Testing instructions

1. From `creator/`, run the unit tests with PHP 8.3 or 8.4: `php vendor/bin/phpunit --testsuite Unit`. The five `DenyListSizeGuardTest` cases should pass.
2. Confirm a normal run still writes the files: `php artisan ded:create-files`, then check `denyDomains.txt` updated as usual.
3. To exercise the guard, temporarily lower `$shrinkThreshold` or point a deny source at an unreachable URL, run the command, and confirm it exits non-zero, logs the abort message, and leaves the existing files unchanged.

## Notes

* CI runs the command directly and does not run PHPUnit, so the new tests are for local and contributor use.
* There is a pre-existing, unrelated failure in `tests/Feature/ExampleTest.php` (`Fideloper\Proxy\TrustProxies` not found, leftover Laravel scaffolding). It is out of scope here and is a candidate for a separate cleanup.