### PR TITLE
Fix secure-domain matching to use label boundaries instead of eTLD+1

### DIFF
--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -230,27 +230,71 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     }
 
     /**
-     * Remove the secure domains from the deny domains.
+     * Remove the secure domains, and any of their subdomains, from the deny domains.
      *
      * @param array $domains
      * @return array
      */
     protected function removeSecureDomains(array $domains): array
     {
-        return array_udiff($domains, $this->secureDomainsArray, function ($domain, $secureDomain) {
-            // Remove domain with subdomain if the main domain is in the secure domains array
-            $matchesDomain = [];
-            $matchesSecureDomain = [];
-            preg_match('/(?<=\.)[^.]+\.[^.]+$/', $domain, $matchesDomain);
-            if (isset($matchesDomain[0])) {
-                $domain = $matchesDomain[0];
-            }
-            preg_match('/(?<=\.)[^.]+\.[^.]+$/', $secureDomain, $matchesSecureDomain);
-            if (isset($matchesSecureDomain[0])) {
-                $secureDomain = $matchesSecureDomain[0];
-            }
-            return strcmp($domain, $secureDomain);
+        $secureLookup = $this->buildSecureLookup($this->secureDomainsArray ?? []);
+
+        return array_filter($domains, function ($domain) use ($secureLookup) {
+            return !$this->isSecureDomain($domain, $secureLookup);
         });
+    }
+
+    /**
+     * Build a fast lookup set (domain => true) from the raw secure domains list,
+     * skipping blank lines and comments.
+     *
+     * @param array $secureDomains
+     * @return array
+     */
+    protected function buildSecureLookup(array $secureDomains): array
+    {
+        $lookup = [];
+        foreach ($this->removeLinesWithoutDomain($secureDomains) as $secureDomain) {
+            $secureDomain = trim($secureDomain);
+            if ($secureDomain !== '') {
+                $lookup[$secureDomain] = true;
+            }
+        }
+
+        return $lookup;
+    }
+
+    /**
+     * Decide whether a domain is secured: it either matches a secure domain
+     * exactly or is a subdomain of one. Matching happens on label boundaries,
+     * so "myexample.com" is not treated as a subdomain of "example.com", and
+     * "evil.co.uk" is not removed because of a secure "good.co.uk".
+     *
+     * @param string $domain
+     * @param array $secureLookup
+     * @return bool
+     */
+    public function isSecureDomain(string $domain, array $secureLookup): bool
+    {
+        if ($domain === '') {
+            return false;
+        }
+
+        if (isset($secureLookup[$domain])) {
+            return true;
+        }
+
+        $labels = explode('.', $domain);
+        // The smallest parent worth checking has two labels (a registrable domain).
+        $lastParentIndex = count($labels) - 2;
+        for ($i = 1; $i <= $lastParentIndex; $i++) {
+            $parent = implode('.', array_slice($labels, $i));
+            if (isset($secureLookup[$parent])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/creator/tests/Unit/SecureDomainMatchingTest.php
+++ b/creator/tests/Unit/SecureDomainMatchingTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\CreateDisposableEmailDomainsFilesCommand;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class SecureDomainMatchingTest extends TestCase
+{
+    private CreateDisposableEmailDomainsFilesCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->command = new CreateDisposableEmailDomainsFilesCommand;
+    }
+
+    public function test_exact_domain_match_is_secure(): void
+    {
+        $this->assertTrue($this->command->isSecureDomain('example.com', ['example.com' => true]));
+    }
+
+    public function test_subdomain_of_a_secure_domain_is_secure(): void
+    {
+        $this->assertTrue($this->command->isSecureDomain('mail.example.com', ['example.com' => true]));
+    }
+
+    public function test_deep_subdomain_of_a_secure_domain_is_secure(): void
+    {
+        $this->assertTrue($this->command->isSecureDomain('a.b.example.com', ['example.com' => true]));
+    }
+
+    public function test_unrelated_domain_is_not_secure(): void
+    {
+        $this->assertFalse($this->command->isSecureDomain('notexample.com', ['example.com' => true]));
+    }
+
+    public function test_domain_sharing_a_suffix_but_not_a_label_boundary_is_not_secure(): void
+    {
+        // "myexample.com" ends with the text "example.com" but is not a subdomain of it.
+        $this->assertFalse($this->command->isSecureDomain('myexample.com', ['example.com' => true]));
+    }
+
+    public function test_different_domain_under_a_multi_part_tld_is_not_secure(): void
+    {
+        // The previous eTLD+1 logic reduced both to "co.uk" and wrongly treated them as equal.
+        $this->assertFalse($this->command->isSecureDomain('evil.co.uk', ['good.co.uk' => true]));
+    }
+
+    public function test_subdomain_under_a_multi_part_tld_is_secure(): void
+    {
+        $this->assertTrue($this->command->isSecureDomain('mail.good.co.uk', ['good.co.uk' => true]));
+    }
+
+    public function test_remove_secure_domains_keeps_only_unrelated_domains(): void
+    {
+        $this->setSecureDomains(['example.com', 'good.co.uk', '# a comment', '']);
+
+        $result = array_values($this->invokeRemoveSecureDomains([
+            'example.com',      // exact match -> removed
+            'mail.example.com', // subdomain -> removed
+            'notexample.com',   // unrelated -> kept
+            'evil.co.uk',       // different domain on the same multi-part TLD -> kept
+            'mail.good.co.uk',  // subdomain on a multi-part TLD -> removed
+        ]));
+
+        $this->assertSame(['notexample.com', 'evil.co.uk'], $result);
+    }
+
+    private function setSecureDomains(array $domains): void
+    {
+        $property = (new ReflectionClass($this->command))->getProperty('secureDomainsArray');
+        $property->setAccessible(true);
+        $property->setValue($this->command, $domains);
+    }
+
+    private function invokeRemoveSecureDomains(array $domains): array
+    {
+        $method = (new ReflectionClass($this->command))->getMethod('removeSecureDomains');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->command, $domains);
+    }
+}


### PR DESCRIPTION
## Proposed changes

* Rewrite `removeSecureDomains` so a secure entry removes a deny domain only when it matches exactly or is a true subdomain, matched on label boundaries.
* Replace the eTLD+1 regex (`/(?<=\.)[^.]+\.[^.]+$/`) with a hash-set lookup plus a small `isSecureDomain` predicate and a `buildSecureLookup` helper.
* Add unit tests for the matching logic, including the cases the old code got wrong.

## Why are these changes being made?

The old `removeSecureDomains` reduced both the deny domain and the secure domain to their last two labels and compared those. That assumes every domain sits under a single-label TLD, which is not true for `.co.uk`, `.com.br`, and similar multi-part suffixes.

The effect: adding a single domain on a multi-part TLD to `secureDomains.txt`, say `good.co.uk`, would reduce to `co.uk` and then clear **every** `*.co.uk` domain out of the deny list. One allowlist request could quietly unblock a whole public suffix. No multi-part-TLD entries exist in `secureDomains.txt` today, so the bug is dormant, but it would fire the first time such a domain is added (and these allowlist requests do come in, see #38 and #39).

The new approach answers the actual question: is this deny domain the secured domain itself, or a subdomain of it? It checks the domain against a lookup set, then walks its parent labels (`a.b.example.com` -> `b.example.com` -> `example.com`). Matching on label boundaries also avoids the substring trap where `myexample.com` looks like it ends with `example.com` but is a different registrable domain.

This needs no Public Suffix List dependency. A PSL answers "what is the registrable domain of an arbitrary name," which is not the question here; we only need to compare against specific secured domains. The lookup-set approach is also faster than the previous `array_udiff` with a per-comparison regex.

Behavior is unchanged for the current data: all 223 entries in `secureDomains.txt` have two labels, and for two-label secure entries the new and old logic produce identical results. The only difference is the multi-part-TLD bug fix and more precise handling if a subdomain is ever added to the secure list.

## Testing instructions

1. From `creator/`, run the unit tests with PHP 8.3 or 8.4: `php vendor/bin/phpunit --testsuite Unit`. The eight `SecureDomainMatchingTest` cases should pass.
2. The `test_remove_secure_domains_keeps_only_unrelated_domains` case fails against the old implementation (it removes `evil.co.uk`) and passes with this change, which demonstrates the fix.
3. Optionally run `php artisan ded:create-files` and confirm `denyDomains.txt` is unchanged versus the previous run, aside from normal upstream churn.

## Notes

* The pre-existing `tests/Feature/ExampleTest.php` failure (`Fideloper\Proxy\TrustProxies` not found, leftover scaffolding) is unrelated and out of scope.