### PR TITLE
Fetch source lists over Guzzle with timeouts, retries and status checks

### DIFF
--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -3,8 +3,16 @@
 namespace App\Console\Commands;
 
 use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Utils;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
 class CreateDisposableEmailDomainsFilesCommand extends Command
 {
@@ -100,6 +108,21 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     protected float $shrinkThreshold = 0.9;
 
     /**
+     * The HTTP client used to fetch the source lists. Lazily created so it can
+     * be replaced with a mock in tests.
+     *
+     * @var ClientInterface|null
+     */
+    protected ?ClientInterface $client = null;
+
+    /**
+     * How many times a failed request is retried before it is given up on.
+     *
+     * @var int
+     */
+    protected int $maxRetries = 2;
+
+    /**
      * The name and signature of the console command.
      *
      * @var string
@@ -188,23 +211,146 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     {
         $domains = [];
 
-        foreach ($textFiles as $textFile) {
-            try {
-                $domains = array_merge($domains, file($textFile, FILE_IGNORE_NEW_LINES));
-            } catch (\Exception $error) {
-                Log::error('Error reading ' . $textFile . PHP_EOL . $error);
-            }
+        foreach ($this->fetchBodies($textFiles) as $body) {
+            $domains = array_merge($domains, $this->linesFromText($body));
         }
 
-        foreach ($jsonFiles as $jsonFile) {
-            try {
-                $domains = array_merge($domains, json_decode(file_get_contents($jsonFile), true));
-            } catch (\Exception $error) {
-                Log::error('Error reading ' . $jsonFile . PHP_EOL . $error);
-            }
+        foreach ($this->fetchBodies($jsonFiles) as $body) {
+            $domains = array_merge($domains, $this->decodeJsonDomains($body));
         }
 
         return $domains;
+    }
+
+    /**
+     * Fetch a list of URLs concurrently and return the bodies of the ones that
+     * answered with HTTP 200, keyed by URL. Anything else (a non-200 status or
+     * a transport failure) is logged and skipped, so a single broken source
+     * cannot inject an error page or abort the whole run.
+     *
+     * @param array $urls
+     * @return array
+     */
+    protected function fetchBodies(array $urls): array
+    {
+        $client = $this->client();
+
+        $promises = [];
+        foreach ($urls as $url) {
+            $promises[$url] = $client->getAsync($url);
+        }
+
+        $bodies = [];
+        foreach (Utils::settle($promises)->wait() as $url => $result) {
+            if ($result['state'] !== 'fulfilled') {
+                Log::error('Error fetching ' . $url . PHP_EOL . $result['reason']->getMessage());
+                continue;
+            }
+
+            $response = $result['value'];
+            if ($response->getStatusCode() !== 200) {
+                Log::warning('Skipping ' . $url . ': HTTP ' . $response->getStatusCode());
+                continue;
+            }
+
+            $bodies[$url] = (string) $response->getBody();
+        }
+
+        return $bodies;
+    }
+
+    /**
+     * Split a fetched text body into lines, dropping the trailing newline.
+     * Mirrors file(..., FILE_IGNORE_NEW_LINES) but works on a string.
+     *
+     * @param string $body
+     * @return array
+     */
+    public function linesFromText(string $body): array
+    {
+        $body = rtrim($body, "\r\n");
+        if ($body === '') {
+            return [];
+        }
+
+        return preg_split('/\r\n|\r|\n/', $body);
+    }
+
+    /**
+     * Decode a JSON body into a list of domains, returning an empty array when
+     * the body is not valid JSON or is not an array.
+     *
+     * @param string $body
+     * @return array
+     */
+    public function decodeJsonDomains(string $body): array
+    {
+        $decoded = json_decode($body, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * Decide whether a failed request should be retried: on a connection error
+     * or a 5xx response, up to $maxRetries times.
+     *
+     * @param int $retries
+     * @param ResponseInterface|null $response
+     * @param Throwable|null $exception
+     * @return bool
+     */
+    public function shouldRetry(int $retries, ?ResponseInterface $response = null, ?Throwable $exception = null): bool
+    {
+        if ($retries >= $this->maxRetries) {
+            return false;
+        }
+
+        if ($exception instanceof ConnectException) {
+            return true;
+        }
+
+        return $response !== null && $response->getStatusCode() >= 500;
+    }
+
+    /**
+     * Replace the HTTP client, used to inject a mock client in tests.
+     *
+     * @param ClientInterface $client
+     * @return void
+     */
+    public function setClient(ClientInterface $client): void
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Build (once) the HTTP client used to fetch the sources, with a timeout,
+     * an identifying User-Agent, and a retry on transient failures.
+     *
+     * @return ClientInterface
+     */
+    protected function client(): ClientInterface
+    {
+        if ($this->client === null) {
+            $stack = HandlerStack::create();
+            $stack->push(Middleware::retry(
+                fn (int $retries, $request, ?ResponseInterface $response = null, ?Throwable $exception = null): bool
+                    => $this->shouldRetry($retries, $response, $exception),
+                fn (int $retries): int => $retries * 1000
+            ));
+
+            $this->client = new Client([
+                'handler' => $stack,
+                'timeout' => 30,
+                'connect_timeout' => 10,
+                'http_errors' => false,
+                'headers' => [
+                    'User-Agent' => 'amieiro/disposable-email-domains generator (+https://github.com/amieiro/disposable-email-domains)',
+                ],
+            ]);
+        }
+
+        return $this->client;
     }
 
     /**

--- a/creator/tests/Feature/FetchBodiesTest.php
+++ b/creator/tests/Feature/FetchBodiesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\CreateDisposableEmailDomainsFilesCommand;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Log;
+use ReflectionClass;
+use Tests\TestCase;
+
+class FetchBodiesTest extends TestCase
+{
+    private CreateDisposableEmailDomainsFilesCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Absorb the warning/error log calls so the test does not write log files.
+        Log::spy();
+        $this->command = new CreateDisposableEmailDomainsFilesCommand;
+    }
+
+    public function test_fetch_bodies_returns_only_the_successful_responses(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], "a.com\nb.com"),
+            new Response(404, [], 'not found'),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock), 'http_errors' => false]);
+        $this->command->setClient($client);
+
+        $bodies = $this->invokeFetchBodies(['https://u1.test', 'https://u2.test']);
+
+        $this->assertSame(['https://u1.test' => "a.com\nb.com"], $bodies);
+    }
+
+    private function invokeFetchBodies(array $urls): array
+    {
+        $method = (new ReflectionClass($this->command))->getMethod('fetchBodies');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->command, $urls);
+    }
+}

--- a/creator/tests/Unit/RobustFetchingTest.php
+++ b/creator/tests/Unit/RobustFetchingTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\CreateDisposableEmailDomainsFilesCommand;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class RobustFetchingTest extends TestCase
+{
+    private CreateDisposableEmailDomainsFilesCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->command = new CreateDisposableEmailDomainsFilesCommand;
+    }
+
+    public function test_lines_from_text_splits_on_newlines(): void
+    {
+        $this->assertSame(['a.com', 'b.com', 'c.com'], $this->command->linesFromText("a.com\nb.com\nc.com"));
+    }
+
+    public function test_lines_from_text_handles_carriage_returns(): void
+    {
+        $this->assertSame(['a.com', 'b.com'], $this->command->linesFromText("a.com\r\nb.com"));
+    }
+
+    public function test_lines_from_text_preserves_internal_blank_lines(): void
+    {
+        $this->assertSame(['a.com', '', 'c.com'], $this->command->linesFromText("a.com\n\nc.com"));
+    }
+
+    public function test_lines_from_text_drops_the_trailing_newline(): void
+    {
+        $this->assertSame(['a.com'], $this->command->linesFromText("a.com\n"));
+    }
+
+    public function test_lines_from_text_on_empty_string_is_empty(): void
+    {
+        $this->assertSame([], $this->command->linesFromText(''));
+    }
+
+    public function test_decode_json_domains_returns_the_array(): void
+    {
+        $this->assertSame(['a.com', 'b.com'], $this->command->decodeJsonDomains('["a.com","b.com"]'));
+    }
+
+    public function test_decode_json_domains_on_invalid_json_returns_empty(): void
+    {
+        $this->assertSame([], $this->command->decodeJsonDomains('this is not json'));
+    }
+
+    public function test_decode_json_domains_on_non_array_returns_empty(): void
+    {
+        $this->assertSame([], $this->command->decodeJsonDomains('"a.com"'));
+    }
+
+    public function test_retries_on_a_connection_error(): void
+    {
+        $exception = new ConnectException('boom', new Request('GET', 'https://u.test'));
+        $this->assertTrue($this->command->shouldRetry(0, null, $exception));
+    }
+
+    public function test_retries_on_a_server_error(): void
+    {
+        $this->assertTrue($this->command->shouldRetry(0, new Response(503), null));
+    }
+
+    public function test_does_not_retry_on_a_successful_response(): void
+    {
+        $this->assertFalse($this->command->shouldRetry(0, new Response(200), null));
+    }
+
+    public function test_does_not_retry_after_the_maximum_attempts(): void
+    {
+        $this->assertFalse($this->command->shouldRetry(2, new Response(503), null));
+    }
+}


### PR DESCRIPTION
## Proposed changes

* Rewrite `obtainAllDomains` to fetch every source through a Guzzle client instead of `file()` / `file_get_contents()`.
* The client fetches all URLs concurrently, sets a 30s timeout and a 10s connect timeout, sends an identifying `User-Agent`, and retries connection errors and 5xx responses up to twice.
* Only responses with HTTP 200 are parsed. Non-200 responses and transport failures are logged and skipped.
* Extract `linesFromText`, `decodeJsonDomains`, and `shouldRetry` as small testable methods, and add `setClient` so a mock client can be injected.
* Add unit tests for the parsing and retry logic, plus a feature test that drives `fetchBodies` with a mocked HTTP client.

## Why are these changes being made?

The list was fetched with `file($url)` and `file_get_contents($url)`. That has no timeout, no retry, no `User-Agent`, runs one request at a time, and does not inspect the HTTP status. A slow or hanging source stalls the run, a flaky source fails on a transient blip, and some hosts reject the default PHP user agent outright. When a fetch failed, the old code relied on `array_merge` throwing a `TypeError` on the `false` return, which the surrounding `try/catch` swallowed, so a dropped source was invisible.

Guzzle is already a dependency, so this uses it properly:

- A timeout means one unresponsive host can no longer hang the whole job.
- Retrying connection errors and 5xx responses absorbs transient failures that previously dropped a source for a full cycle.
- Checking for HTTP 200 means a 404 or maintenance page is skipped instead of being parsed as domains.
- A descriptive `User-Agent` reduces the chance of being blocked and identifies the crawler to source maintainers.
- Concurrent requests make the run faster.

This pairs with the shrinkage guard already on `master`: this change reduces how often a source silently drops out, and the guard catches the case where enough of them do that the list collapses.

The fetching is split so the logic is unit testable without the network. `linesFromText` and `decodeJsonDomains` turn a response body into domains, `shouldRetry` decides on retries, and `fetchBodies` orchestrates the concurrent calls and the 200 check. The body parsing keeps the previous behaviour: text bodies are split the way `file(..., FILE_IGNORE_NEW_LINES)` did, and invalid or non-array JSON now yields an empty array instead of tripping a `TypeError`.

## Testing instructions

1. From `creator/`, run the unit tests with PHP 8.3 or 8.4: `php vendor/bin/phpunit --testsuite Unit`. The twelve `RobustFetchingTest` cases should pass.
2. Run the feature test: `php vendor/bin/phpunit --filter FetchBodiesTest`. It confirms only the 200 response is returned and the 404 is skipped.
3. End to end: run `php artisan ded:create-files` and confirm it completes and writes the files. In my run it finished in about three seconds and produced a deny list within normal churn of the previous one (198,469 -> 198,402).

## Notes

* No `composer.json` change: `guzzlehttp/guzzle` is already required, and `psr/http-message` ships with it.
* The pre-existing `tests/Feature/ExampleTest.php` failure (`Fideloper\Proxy\TrustProxies` not found) is unrelated leftover scaffolding and is the target of the next cleanup PR (#8).