### PR TITLE
Normalize domains to a canonical lowercase form

### DIFF
--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -165,6 +165,8 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
             $allowDomains = $this->removeLinesWithoutDomain($allowDomains);
             $denyDomains = $this->cleanDomains($denyDomains);
             $allowDomains = $this->cleanDomains($allowDomains);
+            $denyDomains = $this->normalizeDomains($denyDomains);
+            $allowDomains = $this->normalizeDomains($allowDomains);
 
             $denyDomains = $this->removeSecureDomains($denyDomains);
             $denyDomains = $this->removeDuplicates($denyDomains);
@@ -361,7 +363,8 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
      */
     protected function addSecureDomains(array $domains): array
     {
-        $secureDomains = $this->removeLinesWithoutDomain( $this->secureDomainsArray );
+        $secureDomains = $this->normalizeDomains($this->removeLinesWithoutDomain($this->secureDomainsArray));
+
         return array_merge($domains, $secureDomains);
     }
 
@@ -401,6 +404,47 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     }
 
     /**
+     * Normalize a list of domains, dropping any that normalize to an empty string.
+     *
+     * @param array $domains
+     * @return array
+     */
+    public function normalizeDomains(array $domains): array
+    {
+        $normalized = [];
+        foreach ($domains as $domain) {
+            $domain = $this->normalizeDomain($domain);
+            if ($domain !== '') {
+                $normalized[] = $domain;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Normalize a single domain so the lists store one canonical form: trimmed,
+     * without a trailing dot, and lowercased.
+     *
+     * Domains are not converted to punycode here. idn_to_ascii can crash the
+     * intl extension on malformed input, and this command processes hundreds of
+     * thousands of unvetted domains from external sources, so the risk is not
+     * worth it for the rare non-ASCII entry.
+     *
+     * @param string $domain
+     * @return string
+     */
+    public function normalizeDomain(string $domain): string
+    {
+        $domain = rtrim(trim($domain), '.');
+        if ($domain === '') {
+            return '';
+        }
+
+        return mb_strtolower($domain);
+    }
+
+    /**
      * Remove the secure domains, and any of their subdomains, from the deny domains.
      *
      * @param array $domains
@@ -426,7 +470,7 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     {
         $lookup = [];
         foreach ($this->removeLinesWithoutDomain($secureDomains) as $secureDomain) {
-            $secureDomain = trim($secureDomain);
+            $secureDomain = $this->normalizeDomain($secureDomain);
             if ($secureDomain !== '') {
                 $lookup[$secureDomain] = true;
             }

--- a/creator/tests/Unit/NormalizeDomainsTest.php
+++ b/creator/tests/Unit/NormalizeDomainsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\CreateDisposableEmailDomainsFilesCommand;
+use PHPUnit\Framework\TestCase;
+
+class NormalizeDomainsTest extends TestCase
+{
+    private CreateDisposableEmailDomainsFilesCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->command = new CreateDisposableEmailDomainsFilesCommand;
+    }
+
+    public function test_lowercases_the_domain(): void
+    {
+        $this->assertSame('example.com', $this->command->normalizeDomain('Example.COM'));
+    }
+
+    public function test_trims_surrounding_whitespace(): void
+    {
+        $this->assertSame('example.com', $this->command->normalizeDomain('  example.com  '));
+    }
+
+    public function test_strips_a_trailing_dot(): void
+    {
+        $this->assertSame('example.com', $this->command->normalizeDomain('example.com.'));
+    }
+
+    public function test_lowercases_unicode_without_converting_to_punycode(): void
+    {
+        $this->assertSame('münchen.de', $this->command->normalizeDomain('MÜNCHEN.DE'));
+    }
+
+    public function test_leaves_an_existing_punycode_domain_unchanged(): void
+    {
+        $this->assertSame('xn--mnchen-3ya.de', $this->command->normalizeDomain('xn--mnchen-3ya.de'));
+    }
+
+    public function test_preserves_underscores_while_lowercasing(): void
+    {
+        $this->assertSame('foo_bar.com', $this->command->normalizeDomain('Foo_Bar.com'));
+    }
+
+    public function test_lowercases_without_rejecting_unusual_shapes(): void
+    {
+        // Normalization does not validate the domain, it only canonicalizes case
+        // and trimming, so an odd shape is kept rather than dropped.
+        $this->assertSame('a..b.com', $this->command->normalizeDomain('A..B.com'));
+    }
+
+    public function test_an_empty_or_whitespace_string_normalizes_to_empty(): void
+    {
+        $this->assertSame('', $this->command->normalizeDomain('   '));
+    }
+
+    public function test_normalize_domains_maps_and_drops_empty_results(): void
+    {
+        $this->assertSame(
+            ['a.com', 'b.com'],
+            $this->command->normalizeDomains(['A.com', '   ', 'b.com.'])
+        );
+    }
+}


### PR DESCRIPTION
## Proposed changes

* Add `normalizeDomain` and `normalizeDomains` and apply them in the pipeline: every domain in the deny, allow, and secure lists is trimmed, has a trailing dot removed, and is lowercased.
* Normalize the same way when building the secure lookup and when adding secure domains to the allow list, so matching stays consistent.
* Add unit tests for the single-domain and list normalization.

## Why are these changes being made?

The lists were assembled from external sources without a canonical form. Case in particular was not touched, so `Example.com` and `example.com` could both appear, and a fully-qualified `example.com.` would not match `example.com`. The README tells consumers to test membership with an exact `in_array`, which makes case and trailing dots matter: an uppercase or dotted variant slips through a check written against the lowercase form.

Normalizing to a trimmed, dot-stripped, lowercase form gives one canonical entry per domain. In an end-to-end run it removed the handful of mixed-case entries that were present (uppercase count went from a few to zero) and collapsed case variants, with the deny total staying within normal churn.

### Why not punycode

I intended to also convert internationalized domains to punycode with `idn_to_ascii`. I dropped it. Running it across the full set reproducibly crashed the process (exit 255, no output): `idn_to_ascii` can fault the intl/ICU extension on malformed input, and this command feeds it hundreds of thousands of unvetted domains. A crash there is uncatchable from PHP and would break the scheduled run. The lists are overwhelmingly ASCII, so lowercasing alone is the safe, high-value normalization; existing punycode entries already pass through unchanged.

## Testing instructions

1. From `creator/`, run the unit tests with PHP 8.3 or 8.4: `php vendor/bin/phpunit --filter NormalizeDomainsTest`. The nine cases should pass.
2. Run the full suite: `php vendor/bin/phpunit`. It is green.
3. End to end: `php artisan ded:create-files` completes (exit 0), and `grep -c '[A-Z]' denyDomains.txt` reports zero. In my run the deny total was within normal churn of the previous one.

## Notes

* This builds on the Guzzle fetching already on `master`. The normalization step runs after `cleanDomains` and before the secure/allow subtraction.