### PR TITLE
Publish a meta.json with the generated list counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ to suggest some change, improvement, ... you can contact me through the
 - **denyDomains**. List of known e-mail domains used disposable email services and should be blocked. Available in [txt](https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/denyDomains.txt) and [json](https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/denyDomains.json) format.
 - **allowDomains**. List of well-known email domains that are not disposable and should be allowed. Available in [txt](https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/allowDomains.txt) and [json](https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/allowDomains.json) format.
 - **secureDomains**. Internal list of known e-mail domains that are secure. Used to generate the denyDomains files.
+- **meta**. Machine-readable counts of the generated lists, in [json](https://raw.githubusercontent.com/amieiro/disposable-email-domains/master/meta.json) format. The generation time is the file's last commit date.
 
 ## Usage
 

--- a/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
+++ b/creator/app/Console/Commands/CreateDisposableEmailDomainsFilesCommand.php
@@ -98,6 +98,9 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     /* The internal file with the secure domains */
     protected $secureDomainsFile = '../secureDomains.txt';
 
+    /* The file with machine-readable metadata about the generated lists */
+    protected $metaFile = '../meta.json';
+
     /**
      * The minimum fraction of the previous deny list size that a new run must
      * reach before it is allowed to overwrite the files. Guards against an
@@ -190,6 +193,8 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
             $allowDomains = $this->addSecureDomains($allowDomains);
             $allowDomains = $this->removeDuplicates($allowDomains);
             $this->saveToFiles($allowDomains, $this->textAllowFile, $this->jsonAllowFile);
+
+            $this->writeMetadata($this->metaFile, count($denyDomains), count($allowDomains));
 
             //$this->commitChanges();
             
@@ -540,6 +545,39 @@ class CreateDisposableEmailDomainsFilesCommand extends Command
     {
         file_put_contents($textFile, implode(PHP_EOL, array_values($domains)));
         file_put_contents($jsonFile, json_encode(array_values($domains), JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Build the machine-readable metadata for the generated lists.
+     *
+     * Only counts are recorded, not a timestamp: a timestamp would change on
+     * every run and defeat the "commit only when the lists changed" check,
+     * producing a commit every fifteen minutes. The generation time is already
+     * available from the commit date.
+     *
+     * @param int $denyCount
+     * @param int $allowCount
+     * @return array
+     */
+    public function buildMetadata(int $denyCount, int $allowCount): array
+    {
+        return [
+            'denyDomains' => $denyCount,
+            'allowDomains' => $allowCount,
+        ];
+    }
+
+    /**
+     * Write the metadata file as JSON.
+     *
+     * @param string $file
+     * @param int $denyCount
+     * @param int $allowCount
+     * @return void
+     */
+    public function writeMetadata(string $file, int $denyCount, int $allowCount): void
+    {
+        file_put_contents($file, json_encode($this->buildMetadata($denyCount, $allowCount), JSON_PRETTY_PRINT));
     }
 
     /**

--- a/creator/tests/Unit/RunMetadataTest.php
+++ b/creator/tests/Unit/RunMetadataTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\CreateDisposableEmailDomainsFilesCommand;
+use PHPUnit\Framework\TestCase;
+
+class RunMetadataTest extends TestCase
+{
+    private CreateDisposableEmailDomainsFilesCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->command = new CreateDisposableEmailDomainsFilesCommand;
+    }
+
+    public function test_build_metadata_contains_the_counts(): void
+    {
+        $this->assertSame(
+            ['denyDomains' => 100, 'allowDomains' => 5],
+            $this->command->buildMetadata(100, 5)
+        );
+    }
+
+    public function test_write_metadata_writes_parseable_json(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'ded-meta-');
+
+        try {
+            $this->command->writeMetadata($path, 198000, 960);
+
+            $decoded = json_decode(file_get_contents($path), true);
+            $this->assertSame(['denyDomains' => 198000, 'allowDomains' => 960], $decoded);
+        } finally {
+            @unlink($path);
+        }
+    }
+}

--- a/meta.json
+++ b/meta.json
@@ -1,0 +1,4 @@
+{
+    "denyDomains": 198401,
+    "allowDomains": 966
+}


### PR DESCRIPTION
## Proposed changes

* Write `meta.json` at the repository root after a successful run, containing the deny and allow domain counts.
* Add `buildMetadata` and `writeMetadata` to the command, call `writeMetadata` once both lists are saved, and add unit tests.
* Document the file in the README.

Example:

```json
{
    "denyDomains": 198401,
    "allowDomains": 966
}
```

## Why are these changes being made?

Consumers and dashboards often want the size of the lists without downloading and counting a multi-megabyte file. A small JSON next to the lists gives them that directly.

It records counts only, no timestamp, on purpose. A timestamp would change on every run, which would defeat the workflow's "commit only when the lists actually changed" check and produce a commit every fifteen minutes. The generation time is already recoverable from the file's last commit date, so a timestamp field would add churn without adding information.

`meta.json` cannot trigger a commit on its own: it changes only when a count changes, and a count change always comes with a change to the list files themselves, so the existing commit step picks it up with no workflow change.

## Testing instructions

1. From `creator/`, run the unit tests with PHP 8.3 or 8.4: `php vendor/bin/phpunit --filter RunMetadataTest`. Both cases should pass.
2. Run the full suite: `php vendor/bin/phpunit`. It is green.
3. End to end: run `php artisan ded:create-files` and confirm `meta.json` is written with counts that match `wc -l` of `denyDomains.txt` and `allowDomains.txt`.

## Notes

* The committed `meta.json` matches the counts of the current committed list files; the scheduled run keeps it in sync from then on.