### PR TITLE
Run the test suite on pull requests and master pushes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,44 @@
+name: Run tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    name: PHPUnit (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          cd creator
+          composer install -n --prefer-dist
+
+      - name: Prepare Laravel application
+        run: |
+          cd creator
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Run the test suite
+        run: |
+          cd creator
+          php vendor/bin/phpunit


### PR DESCRIPTION
## Proposed changes

* Add `.github/workflows/run-tests.yml`, a workflow that runs the PHPUnit suite.
* Triggers on `pull_request` (opened, synchronize, reopened) and on `push` to `master`.
* Runs on a matrix of PHP 8.3 and 8.4, the versions `composer.json` supports.

## Why are these changes being made?

The project had no automated test run. The generator workflow only regenerates the lists; nothing checked the test suite when a change was proposed. This workflow runs the tests on every pull request and on every push to `master`, so a change that breaks the guard, the secure-domain matching, the fetching, or the normalization is caught in review instead of after merge.

Two details differ from the existing generator workflow on purpose:

- It installs with dev dependencies (`composer install`, not `--no-dev`). PHPUnit, Mockery, and Collision live in `require-dev`, so `--no-dev` would leave nothing to run the tests with.
- It copies `.env` and runs `php artisan key:generate`. `FetchBodiesTest` boots the Laravel application, which expects an environment and an app key.

The matrix runs both supported PHP versions independently (`fail-fast: false`), so a failure on one still reports the result on the other.

## Testing instructions

1. Open or update a pull request and confirm the "Run tests" checks appear and pass for PHP 8.3 and 8.4.
2. Locally, from `creator/`, the same command the workflow runs is green: `php vendor/bin/phpunit` (37 tests).

## Notes

* No style/lint gate is included. The code predates the Laravel Pint preset declared in `.styleci.yml` and diverges from it in many existing files, so a Pint check would fail on code this PR does not touch. Reformatting to the preset would be a separate change.