### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.4']
+        php-version: ['8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can find [here](https://github.com/amieiro/disposable-email-domains/blob/mas
 ## Requirements
 
 The project requires:
-- **PHP 8.4**
+- **PHP 8.4 or 8.5**
 - **Composer 2.x**
 - **Laravel 13.x**
 

--- a/creator/config/database.php
+++ b/creator/config/database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
 
 return [
 
@@ -59,7 +60,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/creator/tests/Feature/FetchBodiesTest.php
+++ b/creator/tests/Feature/FetchBodiesTest.php
@@ -40,7 +40,6 @@ class FetchBodiesTest extends TestCase
     private function invokeFetchBodies(array $urls): array
     {
         $method = (new ReflectionClass($this->command))->getMethod('fetchBodies');
-        $method->setAccessible(true);
 
         return $method->invoke($this->command, $urls);
     }

--- a/creator/tests/Unit/SecureDomainMatchingTest.php
+++ b/creator/tests/Unit/SecureDomainMatchingTest.php
@@ -71,14 +71,12 @@ class SecureDomainMatchingTest extends TestCase
     private function setSecureDomains(array $domains): void
     {
         $property = (new ReflectionClass($this->command))->getProperty('secureDomainsArray');
-        $property->setAccessible(true);
         $property->setValue($this->command, $domains);
     }
 
     private function invokeRemoveSecureDomains(array $domains): array
     {
         $method = (new ReflectionClass($this->command))->getMethod('removeSecureDomains');
-        $method->setAccessible(true);
 
         return $method->invoke($this->command, $domains);
     }


### PR DESCRIPTION
## Proposed changes

* Add PHP 8.5 to the test workflow matrix, so the suite runs on both 8.4 and 8.5.
* Remove the `ReflectionProperty::setAccessible()` / `ReflectionMethod::setAccessible()` calls in the tests. They have been a no-op since PHP 8.1, and PHP 8.5 reports them as deprecated.
* Replace the deprecated `PDO::MYSQL_ATTR_SSL_CA` constant in `config/database.php` with `Pdo\Mysql::ATTR_SSL_CA` (Pint imported it as `use Pdo\Mysql`).
* Update the README to list PHP 8.4 or 8.5.

## Why are these changes being made?

The `php` constraint is already `^8.4`, which permits 8.5, so "supporting 8.5" is really about proving the suite runs clean on it and adding CI coverage. `composer.json` is unchanged, and the Composer platform stays pinned at `8.4.1` (the minimum supported version) so dependencies still resolve for 8.4.

Running the suite on PHP 8.5 surfaced three deprecations, all in code this project owns:

- Two `setAccessible(true)` calls in the test reflection helpers. Reflection has been accessible without that call since PHP 8.1, and the project now requires 8.4+, so the calls are pure noise. Removed.
- `PDO::MYSQL_ATTR_SSL_CA` in the stock database config. PHP 8.5 deprecates the `PDO::MYSQL_*` constants in favour of the `Pdo\Mysql` class. The reference sits inside an `extension_loaded('pdo_mysql')` guard, so it is inert in CI (which does not load `pdo_mysql`) and only fires in local PHP builds that do; swapping the constant makes 8.5 clean everywhere.

`phpunit.xml` enables `failOnWarning` and `failOnRisky` but not `failOnDeprecation`, so these never failed the build. Fixing them keeps the 8.5 run genuinely clean rather than green-with-noise.

## How this was verified

Locally on PHP 8.4.21 and PHP 8.5.6:

1. `php vendor/bin/phpunit` on 8.4: 37 tests, clean.
2. `php vendor/bin/phpunit` on 8.5: 37 tests, zero deprecations (was 3 before this change).
3. `php vendor/bin/pint --test` passes.
4. `php artisan ded:create-files` exits 0 on both 8.4 and 8.5.

## Notes

* The generator workflow (`run-every-quarter-hour.yml`) stays on PHP 8.4; this PR only widens test coverage to also include 8.5.